### PR TITLE
feat: pokecard and page details integration

### DIFF
--- a/pokedex/src/components/BaseStats/BaseStats.jsx
+++ b/pokedex/src/components/BaseStats/BaseStats.jsx
@@ -1,77 +1,27 @@
 import { StatisticBar, StatisticName, StatisticValue } from "./styles.jsx";
 import { Table, Tr, Td, Tbody } from "@chakra-ui/react";
 
-function BaseStats() {
+function BaseStats({ stats, color }) {
   return (
     <Table>
       <Tbody>
-        <Tr>
-          <Td>
-            <StatisticName>HP</StatisticName>
-          </Td>
-          <Td>
-            <StatisticValue>039</StatisticValue>
-          </Td>
-          <Td>
-            <StatisticBar src="images/stats-bar.png" />
-          </Td>
-        </Tr>
-        <Tr>
-          <Td>
-            <StatisticName>ATTACK</StatisticName>
-          </Td>
-          <Td>
-            <StatisticValue>052</StatisticValue>
-          </Td>
-          <Td>
-            <StatisticBar src="images/stats-bar.png" />
-          </Td>
-        </Tr>
-        <Tr>
-          <Td>
-            <StatisticName>DEFENSE</StatisticName>
-          </Td>
-
-          <Td>
-            <StatisticValue>043</StatisticValue>
-          </Td>
-          <Td>
-            <StatisticBar src="images/stats-bar.png" />
-          </Td>
-        </Tr>
-        <Tr>
-          <Td>
-            <StatisticName>SPECIAL-ATTACK</StatisticName>
-          </Td>
-          <Td>
-            <StatisticValue>060</StatisticValue>
-          </Td>
-          <Td>
-            <StatisticBar src="images/stats-bar.png" />
-          </Td>
-        </Tr>
-        <Tr>
-          <Td>
-            <StatisticName>SPECIAL-DEFENSE</StatisticName>
-          </Td>
-          <Td>
-            <StatisticValue>050</StatisticValue>
-          </Td>
-          <Td>
-            <StatisticBar src="images/stats-bar.png" />
-          </Td>
-        </Tr>
-        <Tr>
-          <Td>
-            <StatisticName>SPEED</StatisticName>
-          </Td>
-          <Td>
-            <StatisticValue>065</StatisticValue>
-          </Td>
-          <Td>
-            <StatisticBar src="images/stats-bar.png" />
-          </Td>
-        </Tr>
+        {stats?.map((slot, index) => {
+          return (
+            <Tr key={index}>
+              <Td>
+                <StatisticName color={color}>
+                  {slot.stat.name?.toUpperCase()}
+                </StatisticName>
+              </Td>
+              <Td>
+                <StatisticValue>{slot?.base_stat}</StatisticValue>
+              </Td>
+              <Td>
+                <StatisticBar src="/images/stats-bar.png" alt="" />
+              </Td>
+            </Tr>
+          );
+        })}
       </Tbody>
     </Table>
   );

--- a/pokedex/src/components/BaseStats/styles.jsx
+++ b/pokedex/src/components/BaseStats/styles.jsx
@@ -9,7 +9,7 @@ export const StatisticName = styled.div`
 
   border-right: 1px solid #e0e0e0;
 
-  color: #f57d31;
+  color: ${(props) => props.color};
 `;
 
 export const StatisticValue = styled.div`

--- a/pokedex/src/components/MainAttacks/MainAttacks.jsx
+++ b/pokedex/src/components/MainAttacks/MainAttacks.jsx
@@ -1,16 +1,17 @@
 import { Container, OrangeBox, StatisticName, Title } from "./styles.jsx";
 
-function MainAttacks() {
+function MainAttacks({ moves, color }) {
   return (
     <Container>
-      <Title>Main Attacks</Title>
-      <OrangeBox>
-        <StatisticName>HP</StatisticName>
-        <StatisticName>ATTACK</StatisticName>
-        <StatisticName>DEFENSE</StatisticName>
-        <StatisticName>SPECIAL-ATTACK</StatisticName>
-        <StatisticName>SPECIAL-DEFENSE</StatisticName>
-        <StatisticName>SPEED</StatisticName>
+      <Title color={color}>Main Attacks</Title>
+      <OrangeBox color={color}>
+        {moves?.slice(0, 5).map((slot, index) => {
+          return (
+            <StatisticName key={index}>
+              {slot.move.name?.toUpperCase()}
+            </StatisticName>
+          );
+        })}
       </OrangeBox>
     </Container>
   );

--- a/pokedex/src/components/MainAttacks/styles.jsx
+++ b/pokedex/src/components/MainAttacks/styles.jsx
@@ -13,7 +13,7 @@ export const Title = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  color: #f57d31;
+  color: ${(props) => props.color};
   font-weight: 700;
   font-size: 24px;
   line-height: 32px;
@@ -26,16 +26,16 @@ export const OrangeBox = styled.div`
 
   margin-bottom: 8px;
 
-  background: #f57d31;
-  background-image: url("images/details-background.png");
-  background-position: 300% top;
+  background: ${(props) => props.color};
+  background-image: url("/images/details-background.png");
+  background-position: 325% top;
   background-repeat: no-repeat;
   border-radius: 12px;
 `;
 
 export const StatisticName = styled.div`
   font-weight: 700;
-  font-size: 10px;
+  font-size: 12px;
   line-height: 16px;
   text-align: center;
 

--- a/pokedex/src/components/PokeCards.jsx
+++ b/pokedex/src/components/PokeCards.jsx
@@ -9,6 +9,7 @@ import {
   } from '@chakra-ui/react';
   import { useEffect, useState } from 'react';
   import axios from 'axios';
+import { Link } from 'react-router-dom';
   
   
  const PokeCards = (props) => {
@@ -74,7 +75,7 @@ import {
             </Heading>
             <Stack direction={'row'} align={'center'}>
              <button onClick={props.onClick}>{props.nameButton}</button>
-             <button>Ver Detalhes</button>
+             <Link to={`/detalhes/${props.name}`}><button>Ver Detalhes</button></Link>
             </Stack>
           </Stack>
         </Box>

--- a/pokedex/src/hooks/useColor.jsx
+++ b/pokedex/src/hooks/useColor.jsx
@@ -1,0 +1,43 @@
+import { useState, useEffect } from "react";
+
+function useColor() {
+  const [color, setColor] = useState("");
+
+  useEffect(() => {
+    switch (color) {
+      case "fire":
+        setColor("#f57d31");
+        break;
+      case "grass":
+        setColor("#74CB48");
+        break;
+      case "water":
+        setColor("#6493EB");
+        break;
+      case "bug":
+        setColor("#A7B723");
+        break;
+      case "electric":
+        setColor("#F9CF30");
+        break;
+      case "ghost":
+        setColor("#70559B");
+        break;
+      case "psychic":
+        setColor("#B7B9D0");
+        break;
+      case "steel":
+        setColor("#FB5584");
+        break;
+      case "normal":
+        setColor("#AAA67F");
+        break;
+      default:
+        break;
+    }
+  }, [color]);
+
+  return { color, setColor };
+}
+
+export default useColor;

--- a/pokedex/src/pages/DetailPage/DetailPage.jsx
+++ b/pokedex/src/pages/DetailPage/DetailPage.jsx
@@ -9,38 +9,71 @@ import {
   Skills,
   WhiteBox,
   TypeContainer,
+  GridContainer,
 } from "./styles";
 
 import BaseStats from "../../components/BaseStats/BaseStats.jsx";
 import MainAttacks from "../../components/MainAttacks/MainAttacks";
+import Header from "../../components/Header";
+import { useParams } from "react-router-dom";
+import { useEffect, useState } from "react";
+import api from "../../services/api";
+import useColor from "../../hooks/useColor";
 
 function DetailPage() {
+  const { name } = useParams();
+  const { color, setColor } = useColor();
+  const [pokemon, setData] = useState({});
+
+  useEffect(() => {
+    api(`pokemon/${name}`)
+      .then((response) => {
+        setData(response.data);
+        setColor(response.data.types[0].type.name);
+      })
+      .catch((error) => {
+        console.error(error);
+      });
+  }, [name, setColor]);
+
   return (
     <Container>
-      <ImgFront>
-        <Image src="images/charmander.png" height={200} width={200} />
-      </ImgFront>
+      <Header />
+      <GridContainer>
+        <ImgFront color={color}>
+          <Image
+            src={pokemon.sprites?.front_default}
+            height={200}
+            width={200}
+          />
+        </ImgFront>
 
-      <ImgBack>
-        <Image src="images/charmander.png" height={200} width={200} />
-      </ImgBack>
+        <ImgBack color={color}>
+          <Image src={pokemon.sprites?.back_default} height={200} width={200} />
+        </ImgBack>
 
-      <Skills>
-        <Name>Charmander</Name>
-        <WhiteBox>
-          <TypeContainer>
-            <Type>Fire</Type>
-            <Type>Grass</Type>
-          </TypeContainer>
-          <BaseStats />
-        </WhiteBox>
-      </Skills>
+        <Skills color={color}>
+          <Name>{pokemon?.name}</Name>
+          <WhiteBox>
+            <TypeContainer>
+              {pokemon.types?.map((slot, index) => {
+                return (
+                  <Type key={index} color={color}>
+                    {slot.type?.name}
+                  </Type>
+                );
+              })}
+            </TypeContainer>
+            <BaseStats stats={pokemon?.stats} color={color} />
+          </WhiteBox>
+        </Skills>
 
-      <MainAttacksContainer>
-        <WhiteBox>
-          <MainAttacks />
-        </WhiteBox>
-      </MainAttacksContainer>
+        <MainAttacksContainer color={color}>
+          <WhiteBox>
+            <MainAttacks moves={pokemon?.moves} color={color} />
+          </WhiteBox>
+        </MainAttacksContainer>
+      </GridContainer>
     </Container>
   );
 }

--- a/pokedex/src/pages/DetailPage/styles.jsx
+++ b/pokedex/src/pages/DetailPage/styles.jsx
@@ -1,8 +1,12 @@
 import styled from "styled-components";
 
 export const Container = styled.main`
+  height: 100vh;
+`;
+
+export const GridContainer = styled.div`
   display: grid;
-  grid-template-areas: "img-front skills main-attacks" "img-back skills main-attacks";
+  grid-template-areas: "img-front" "img-back" "skills" "main-attacks";
 
   gap: 16px;
   padding: 16px;
@@ -10,6 +14,14 @@ export const Container = styled.main`
   font-family: "Poppins";
   background: #ffffff7f;
   border-radius: 12px;
+
+  @media only screen and (min-width: 576px) {
+    grid-template-areas: "img-front main-attacks" "img-back main-attacks" "skills skills";
+  }
+
+  @media only screen and (min-width: 768px) {
+    grid-template-areas: "img-front skills main-attacks" "img-back skills main-attacks";
+  }
 `;
 
 export const ImgFront = styled.div`
@@ -18,7 +30,7 @@ export const ImgFront = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  background: #f57d31;
+  background: ${(props) => props.color};
 
   border-radius: 12px;
 `;
@@ -29,7 +41,7 @@ export const ImgBack = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  background: #f57d31;
+  background: ${(props) => props.color};
 
   border-radius: 12px;
 `;
@@ -42,7 +54,7 @@ export const Skills = styled.div`
   align-items: center;
   padding: 4px;
 
-  background: #f57d31;
+  background: ${(props) => props.color};
   border-radius: 12px;
 `;
 
@@ -53,7 +65,7 @@ export const MainAttacksContainer = styled.div`
   justify-content: center;
   align-items: center;
   padding: 4px;
-  background: #f57d31;
+  background: ${(props) => props.color};
   border-radius: 12px;
 `;
 
@@ -92,7 +104,7 @@ export const Type = styled.div`
   width: 35px;
   height: 20px;
 
-  background: #f57d31;
+  background: ${(props) => props.color};
   border-radius: 10px;
 
   font-weight: 700;

--- a/pokedex/src/routes/Router.js
+++ b/pokedex/src/routes/Router.js
@@ -11,7 +11,7 @@ const Router = () => {
         <BrowserRouter>
         <Routes>
             <Route path='/' element={<Home addPokemon={addPokemon} setAddPokemon={setAddPokemon}/>}/>
-            <Route path='/detalhes' element={<DetailPage/>}/>
+            <Route path='/detalhes/:name' element={<DetailPage/>}/>
             <Route path='/pokedex' element={<Pokedex addPokemon={addPokemon} setAddPokemon={setAddPokemon}/>}/>
         </Routes>
         </BrowserRouter>

--- a/pokedex/src/services/api.js
+++ b/pokedex/src/services/api.js
@@ -1,0 +1,7 @@
+import axios from "axios";
+
+const api = axios.create({
+  baseURL: "https://pokeapi.co/api/v2/",
+});
+
+export default api;


### PR DESCRIPTION
### Integra o card do pokémon, botão ver detalhes, com a página de detalhes.

### Imagens
![image](https://user-images.githubusercontent.com/79323700/178113341-2c06354b-1b99-41a7-9b9a-ba20c8975509.png)
